### PR TITLE
Fix MM syntax

### DIFF
--- a/WarpThrust/RA-NearFuturePropulsion.cfg
+++ b/WarpThrust/RA-NearFuturePropulsion.cfg
@@ -1,4 +1,4 @@
-+PART[ionArgon-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally HERMES
++PART[ionArgon-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally HERMES
 {
 
 	@name = RA-ionArgon-0625
@@ -114,7 +114,7 @@
 	
 }
 
-+PART[ionArgon-0625-2]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally P5
++PART[ionArgon-0625-2]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally P5
 {
 
 	@name = RA-ionArgon-0625-2
@@ -211,7 +211,7 @@
 	
 }
 
-+PART[ionArgon-0625-3]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally X3
++PART[ionArgon-0625-3]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally X3
 {
 
 	@name = RA-ionArgon-0625-3
@@ -338,7 +338,7 @@
 	
 }
 
-+PART[ionXenon-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally ID500
++PART[ionXenon-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally ID500
 {
 
 	@name = RA-ionXenon-0625
@@ -411,7 +411,7 @@
 	
 }
 
-+PART[ionXenon-0625-2]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally HIPEP
++PART[ionXenon-0625-2]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally HIPEP
 {
 
 	@name = RA-ionXenon-0625-2
@@ -481,7 +481,7 @@
 	
 }
 
-+PART[ionXenon-0625-3]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally DS4G
++PART[ionXenon-0625-3]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally DS4G
 {
 
 	@name = RA-ionXenon-0625-3
@@ -664,7 +664,7 @@
 	
 }
 
-+PART[mpdt-25]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
++PART[mpdt-25]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] 
 {
 
 	@name = RA-mpdt-25
@@ -688,7 +688,7 @@
 	
 }
 
-+PART[mpdt-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally SX3 at 0.33
++PART[mpdt-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally SX3 at 0.33
 {
 
 	@name = RA-mpdt-125
@@ -759,7 +759,7 @@
 	}
 }
 
-+PART[mpdt-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
++PART[mpdt-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] 
 {
 
 	@name = RA-mpdt-0625
@@ -785,7 +785,7 @@
 	
 }
 
-+PART[pit-25]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
++PART[pit-25]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] 
 {
 
 	@name = RA-pit-25
@@ -863,7 +863,7 @@
 	
 }
 
-+PART[pit-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally NUPIT at 1.66 scale
++PART[pit-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally NUPIT at 1.66 scale
 {
 
 	@name = RA-pit-125
@@ -971,7 +971,7 @@
 	
 }
 
-+PART[pit-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally FARAD at 0.4 scale
++PART[pit-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] // Originally FARAD at 0.4 scale
 {
 
 	@name = RA-pit-0625
@@ -1048,7 +1048,7 @@
 	
 }
 
-+PART[vasimr-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
++PART[vasimr-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] 
 {
 
 	@name = RA-vasimr-800
@@ -1123,7 +1123,7 @@
 	
 }
 
-+PART[vasimr-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
++PART[vasimr-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThrust] 
 {
 
 	@name = RA-vasimr-125

--- a/WarpThrust/RA-NearFuturePropulsion.cfg
+++ b/WarpThrust/RA-NearFuturePropulsion.cfg
@@ -1,4 +1,4 @@
-+PART[ionArgon-0625]:FOR[RealismOverhaul] // Originally HERMES
++PART[ionArgon-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally HERMES
 {
 
 	@name = RA-ionArgon-0625
@@ -114,7 +114,7 @@
 	
 }
 
-+PART[ionArgon-0625-2]:FOR[RealismOverhaul] // Originally P5
++PART[ionArgon-0625-2]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally P5
 {
 
 	@name = RA-ionArgon-0625-2
@@ -211,7 +211,7 @@
 	
 }
 
-+PART[ionArgon-0625-3]:FOR[RealismOverhaul] // Originally X3
++PART[ionArgon-0625-3]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally X3
 {
 
 	@name = RA-ionArgon-0625-3
@@ -338,7 +338,7 @@
 	
 }
 
-+PART[ionXenon-0625]:FOR[RealismOverhaul] // Originally ID500
++PART[ionXenon-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally ID500
 {
 
 	@name = RA-ionXenon-0625
@@ -411,7 +411,7 @@
 	
 }
 
-+PART[ionXenon-0625-2]:FOR[RealismOverhaul] // Originally HIPEP
++PART[ionXenon-0625-2]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally HIPEP
 {
 
 	@name = RA-ionXenon-0625-2
@@ -481,7 +481,7 @@
 	
 }
 
-+PART[ionXenon-0625-3]:FOR[RealismOverhaul] // Originally DS4G
++PART[ionXenon-0625-3]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally DS4G
 {
 
 	@name = RA-ionXenon-0625-3
@@ -664,7 +664,7 @@
 	
 }
 
-+PART[mpdt-25]:FOR[RealismOverhaul] 
++PART[mpdt-25]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
 {
 
 	@name = RA-mpdt-25
@@ -688,7 +688,7 @@
 	
 }
 
-+PART[mpdt-125]:FOR[RealismOverhaul] // Originally SX3 at 0.33
++PART[mpdt-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally SX3 at 0.33
 {
 
 	@name = RA-mpdt-125
@@ -759,7 +759,7 @@
 	}
 }
 
-+PART[mpdt-0625]:FOR[RealismOverhaul] 
++PART[mpdt-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
 {
 
 	@name = RA-mpdt-0625
@@ -785,7 +785,7 @@
 	
 }
 
-+PART[pit-25]:FOR[RealismOverhaul] 
++PART[pit-25]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
 {
 
 	@name = RA-pit-25
@@ -863,7 +863,7 @@
 	
 }
 
-+PART[pit-125]:FOR[RealismOverhaul] // Originally NUPIT at 1.66 scale
++PART[pit-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally NUPIT at 1.66 scale
 {
 
 	@name = RA-pit-125
@@ -971,7 +971,7 @@
 	
 }
 
-+PART[pit-0625]:FOR[RealismOverhaul] // Originally FARAD at 0.4 scale
++PART[pit-0625]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] // Originally FARAD at 0.4 scale
 {
 
 	@name = RA-pit-0625
@@ -1048,7 +1048,7 @@
 	
 }
 
-+PART[vasimr-125]:FOR[RealismOverhaul] 
++PART[vasimr-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
 {
 
 	@name = RA-vasimr-800
@@ -1123,7 +1123,7 @@
 	
 }
 
-+PART[vasimr-125]:FOR[RealismOverhaul] 
++PART[vasimr-125]:NEEDS[NearFuturePropulsion&RealismOverhaul]:FOR[WarpThurst] 
 {
 
 	@name = RA-vasimr-125

--- a/WarpThrust/RO-FarFutureTech.cfg
+++ b/WarpThrust/RO-FarFutureTech.cfg
@@ -1,4 +1,4 @@
-@PART[fft-rcs-arcjet-1]:FOR[RealismOverhaul]
+@PART[fft-rcs-arcjet-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -140,7 +140,7 @@
 	
 }
 
-@PART[fft-rcs-arcjet-large-1]:FOR[RealismOverhaul]
+@PART[fft-rcs-arcjet-large-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -281,7 +281,7 @@
 	  }
 }
 
-@PART[fft-antimatter-beam-1]:FOR[RealismOverhaul]
+@PART[fft-antimatter-beam-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -308,7 +308,7 @@
 	
 }
 
-@PART[fft-antimatter-microfission-1]:FOR[RealismOverhaul]
+@PART[fft-antimatter-microfission-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -335,7 +335,7 @@
 	
 }
 
-@PART[fft-antimatter-microfusion-1]:FOR[RealismOverhaul]
+@PART[fft-antimatter-microfusion-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -355,7 +355,7 @@
 	
 }
 
-@PART[fft-ffre-plasma-1]:FOR[RealismOverhaul]
+@PART[fft-ffre-plasma-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -382,7 +382,7 @@
 	
 }
 
-@PART[fft-ffre-solid-1]:FOR[RealismOverhaul]
+@PART[fft-ffre-solid-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -409,7 +409,7 @@
 	
 }
 
-@PART[fft-fission-orion-5-1]:FOR[RealismOverhaul]
+@PART[fft-fission-orion-5-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -456,7 +456,7 @@
 	
 }
 
-@PART[fft-fission-zpinch-1]:FOR[RealismOverhaul]
+@PART[fft-fission-zpinch-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -483,7 +483,7 @@
 	
 }
 
-@PART[fft-nswr-1]:FOR[RealismOverhaul]
+@PART[fft-nswr-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -510,7 +510,7 @@
 	
 }
 
-@PART[fft-nswr-2]:FOR[RealismOverhaul]
+@PART[fft-nswr-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -530,7 +530,7 @@
 	
 }
 
-@PART[fft-fusion-axial-zpinch-1]:FOR[RealismOverhaul]
+@PART[fft-fusion-axial-zpinch-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -550,7 +550,7 @@
 	
 }
 
-@PART[fft-fusion-inertial-laser-1]:FOR[RealismOverhaul]
+@PART[fft-fusion-inertial-laser-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -570,7 +570,7 @@
 	
 }
 
-@PART[fft-fusion-inertial-magnetic-1]:FOR[RealismOverhaul]
+@PART[fft-fusion-inertial-magnetic-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -590,7 +590,7 @@
 	
 }
 
-@PART[fft-fusion-magnetic-mirror-1]:FOR[RealismOverhaul]
+@PART[fft-fusion-magnetic-mirror-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -617,7 +617,7 @@
 	
 }
 
-@PART[fft-fusion-magnetic-tokamak-1]:FOR[RealismOverhaul]
+@PART[fft-fusion-magnetic-tokamak-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -637,7 +637,7 @@
 	
 }
 
-@PART[fft-fusion-magnetic-tokamak-aerospike-1]:FOR[RealismOverhaul]
+@PART[fft-fusion-magnetic-tokamak-aerospike-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -665,7 +665,7 @@
 	
 }
 
-@PART[fft-fusion-reactor-25-1]:FOR[RealismOverhaul]
+@PART[fft-fusion-reactor-25-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -680,7 +680,7 @@
 	
 }
 
-@PART[fft-fusion-reactor-375-1]:FOR[RealismOverhaul]
+@PART[fft-fusion-reactor-375-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -695,7 +695,7 @@
 	
 }
 
-@PART[fft-antimatter-factory-1]:FOR[RealismOverhaul]
+@PART[fft-antimatter-factory-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -710,7 +710,7 @@
 	
 }
 
-@PART[fft-atmosphere-scoop-1]:FOR[RealismOverhaul]
+@PART[fft-atmosphere-scoop-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -725,7 +725,7 @@
 	
 }
 
-@PART[fft-exosphere-scoop-1]:FOR[RealismOverhaul]
+@PART[fft-exosphere-scoop-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -740,7 +740,7 @@
 	
 }
 
-@PART[fft-nuclear-smelter-375-1]:FOR[RealismOverhaul]
+@PART[fft-nuclear-smelter-375-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -755,7 +755,7 @@
 	
 }
 
-@PART[fft-regolith-scoop-1]:FOR[RealismOverhaul]
+@PART[fft-regolith-scoop-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -770,7 +770,7 @@
 	
 }
 
-@PART[fft-regolith-scoop-2]:FOR[RealismOverhaul]
+@PART[fft-regolith-scoop-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -785,7 +785,7 @@
 	
 }
 
-@PART[fft-scanner-antimatter-1]:FOR[RealismOverhaul]
+@PART[fft-scanner-antimatter-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -800,7 +800,7 @@
 	
 }
 
-@PART[fft-scanner-gas-1]:FOR[RealismOverhaul]
+@PART[fft-scanner-gas-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -815,7 +815,7 @@
 	
 }
 
-@PART[fft-fueltank-antimatter-ring-75-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-antimatter-ring-75-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -830,7 +830,7 @@
 	
 }
 
-@PART[fft-fueltank-antimatter-tank-5-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-antimatter-tank-5-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -845,7 +845,7 @@
 	
 }
 
-@PART[fft-fueltank-antimatter-tank-5-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-antimatter-tank-5-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -860,7 +860,7 @@
 	
 }
 
-@PART[fft-fueltank-antimatter-tank-5-3]:FOR[RealismOverhaul]
+@PART[fft-fueltank-antimatter-tank-5-3]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -875,7 +875,7 @@
 	
 }
 
-@PART[fft-fueltank-antimatter-tank-5-4]:FOR[RealismOverhaul]
+@PART[fft-fueltank-antimatter-tank-5-4]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -890,7 +890,7 @@
 	
 }
 
-@PART[fft-fueltank-antimatter-tank-25-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-antimatter-tank-25-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -905,7 +905,7 @@
 	
 }
 
-@PART[fft-fueltank-antimatter-tank-25-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-antimatter-tank-25-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -920,7 +920,7 @@
 	
 }
 
-@PART[fft-fueltank-fission-5-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fission-5-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -935,7 +935,7 @@
 	
 }
 
-@PART[fft-fueltank-fission-5-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fission-5-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -950,7 +950,7 @@
 	
 }
 
-@PART[fft-fueltank-fission-25-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fission-25-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -965,7 +965,7 @@
 	
 }
 
-@PART[fft-fueltank-fission-25-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fission-25-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -980,7 +980,7 @@
 	
 }
 
-@PART[fft-fueltank-fission-25-3]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fission-25-3]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -995,7 +995,7 @@
 	
 }
 
-@PART[fft-fueltank-fission-radial-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fission-radial-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1010,7 +1010,7 @@
 	
 }
 
-@PART[fft-fueltank-fission-radial-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fission-radial-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1025,7 +1025,7 @@
 	
 }
 
-@PART[fft-fueltank-fission-radial-3]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fission-radial-3]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1040,7 +1040,7 @@
 	
 }
 
-@PART[fft-fueltank-fusion-5-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fusion-5-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1060,7 +1060,7 @@
 }
 
 
-@PART[fft-fueltank-fusion-10-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fusion-10-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1079,7 +1079,7 @@
 	
 }
 
-@PART[fft-fueltank-fusion-25-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fusion-25-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1098,7 +1098,7 @@
 	
 }
 
-@PART[fft-fueltank-fusion-25-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fusion-25-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1119,7 +1119,7 @@
 	
 }
 
-@PART[fft-fueltank-fusion-375-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fusion-375-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1138,7 +1138,7 @@
 	
 }
 
-@PART[fft-fueltank-fusion-375-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-fusion-375-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1157,7 +1157,7 @@
 	
 }
 
-@PART[fft-fueltank-lithium-25-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-lithium-25-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1172,7 +1172,7 @@
 	
 }
 
-@PART[fft-fueltank-lithium-25-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-lithium-25-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1187,7 +1187,7 @@
 	
 }
 
-@PART[fft-fueltank-lithium-25-3]:FOR[RealismOverhaul]
+@PART[fft-fueltank-lithium-25-3]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1202,7 +1202,7 @@
 	
 }
 
-@PART[fft-fueltank-lithium-radial-125-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-lithium-radial-125-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1217,7 +1217,7 @@
 	
 }
 
-@PART[fft-fueltank-lithium-radial-0625-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-lithium-radial-0625-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1232,7 +1232,7 @@
 	
 }
 
-@PART[fft-fueltank-pulseunits-5-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-pulseunits-5-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1247,7 +1247,7 @@
 	
 }
 
-@PART[fft-fueltank-pulseunits-5-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-pulseunits-5-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1262,7 +1262,7 @@
 	
 }
 
-@PART[fft-fueltank-pulseunits-5-3]:FOR[RealismOverhaul]
+@PART[fft-fueltank-pulseunits-5-3]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1277,7 +1277,7 @@
 	
 }
 
-@PART[fft-fueltank-targets-5-1]:FOR[RealismOverhaul]
+@PART[fft-fueltank-targets-5-1]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	
@@ -1292,7 +1292,7 @@
 	
 }
 
-@PART[fft-fueltank-targets-5-2]:FOR[RealismOverhaul]
+@PART[fft-fueltank-targets-5-2]:NEEDS[FarFutureTechnologies&RealismOverhaul]:FOR[WarpThrust]
 {
 	%RSSROConfig = True
 	

--- a/WarpThrust/StockConfig.cfg
+++ b/WarpThrust/StockConfig.cfg
@@ -1,4 +1,4 @@
-@PART[nuclearEngine]:NEEDS[!RealismOverhaul]
+@PART[nuclearEngine]:NEEDS[!RealismOverhaul]:FOR[WarpThrust]
 {	
 	MODULE
 	{
@@ -6,7 +6,7 @@
 	}
 }
 
-@PART[ionEngine]:NEEDS[!RealismOverhaul]
+@PART[ionEngine]:NEEDS[!RealismOverhaul]:FOR[WarpThrust]
 {	
 	MODULE
 	{

--- a/WarpThrust/WarpThrust FFT configs.cfg
+++ b/WarpThrust/WarpThrust FFT configs.cfg
@@ -1,4 +1,4 @@
-@PART[fft-antimatter-beam-1]:NEEDS[!RealismOverhaul]
+@PART[fft-antimatter-beam-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {	
 	MODULE
 	{
@@ -6,7 +6,7 @@
 	}
 }
 
-@PART[fft-antimatter-microfission-1]:NEEDS[!RealismOverhaul]
+@PART[fft-antimatter-microfission-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[fft-antimatter-microfusion-1]:NEEDS[!RealismOverhaul]
+@PART[fft-antimatter-microfusion-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -22,7 +22,7 @@
 	}
 }
 
-@PART[fft-ffre-plasma-1]:NEEDS[!RealismOverhaul]
+@PART[fft-ffre-plasma-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -30,7 +30,7 @@
 	}	
 }
 
-@PART[fft-ffre-solid-1]:NEEDS[!RealismOverhaul]
+@PART[fft-ffre-solid-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -38,7 +38,7 @@
 	}
 }
 
-@PART[fft-fission-orion-5-1]:NEEDS[!RealismOverhaul]
+@PART[fft-fission-orion-5-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	  MODULE
 	{
@@ -46,7 +46,7 @@
 	}
 }
 
-@PART[fft-fission-zpinch-1]:NEEDS[!RealismOverhaul]
+@PART[fft-fission-zpinch-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -54,7 +54,7 @@
 	}
 }
 
-@PART[fft-nswr-1]:NEEDS[!RealismOverhaul]
+@PART[fft-nswr-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -62,7 +62,7 @@
 	}
 }
 
-@PART[fft-nswr-2]:NEEDS[!RealismOverhaul]
+@PART[fft-nswr-2]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -70,7 +70,7 @@
 	}
 }
 
-@PART[fft-fusion-axial-zpinch-1]:NEEDS[!RealismOverhaul]
+@PART[fft-fusion-axial-zpinch-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -78,7 +78,7 @@
 	}
 }
 
-@PART[fft-fusion-inertial-laser-1]:NEEDS[!RealismOverhaul]
+@PART[fft-fusion-inertial-laser-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -86,7 +86,7 @@
 	}
 }
 
-@PART[fft-fusion-inertial-magnetic-1]:NEEDS[!RealismOverhaul]
+@PART[fft-fusion-inertial-magnetic-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -94,7 +94,7 @@
 	}
 }
 
-@PART[fft-fusion-magnetic-mirror-1]:NEEDS[!RealismOverhaul]
+@PART[fft-fusion-magnetic-mirror-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -102,7 +102,7 @@
 	}
 }
 
-@PART[fft-fusion-magnetic-tokamak-1]:NEEDS[!RealismOverhaul]
+@PART[fft-fusion-magnetic-tokamak-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -110,7 +110,7 @@
 	}
 }
 
-@PART[fft-fusion-magnetic-tokamak-aerospike-1]:NEEDS[!RealismOverhaul]
+@PART[fft-fusion-magnetic-tokamak-aerospike-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
 {
 	MODULE
 	{

--- a/WarpThrust/WarpThrust FFT configs.cfg
+++ b/WarpThrust/WarpThrust FFT configs.cfg
@@ -1,4 +1,4 @@
-@PART[fft-antimatter-beam-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-antimatter-beam-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {	
 	MODULE
 	{
@@ -6,7 +6,7 @@
 	}
 }
 
-@PART[fft-antimatter-microfission-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-antimatter-microfission-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[fft-antimatter-microfusion-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-antimatter-microfusion-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -22,7 +22,7 @@
 	}
 }
 
-@PART[fft-ffre-plasma-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-ffre-plasma-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -30,7 +30,7 @@
 	}	
 }
 
-@PART[fft-ffre-solid-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-ffre-solid-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -38,7 +38,7 @@
 	}
 }
 
-@PART[fft-fission-orion-5-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-fission-orion-5-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	  MODULE
 	{
@@ -46,7 +46,7 @@
 	}
 }
 
-@PART[fft-fission-zpinch-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-fission-zpinch-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -54,7 +54,7 @@
 	}
 }
 
-@PART[fft-nswr-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-nswr-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -62,7 +62,7 @@
 	}
 }
 
-@PART[fft-nswr-2]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-nswr-2]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -70,7 +70,7 @@
 	}
 }
 
-@PART[fft-fusion-axial-zpinch-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-fusion-axial-zpinch-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -78,7 +78,7 @@
 	}
 }
 
-@PART[fft-fusion-inertial-laser-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-fusion-inertial-laser-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -86,7 +86,7 @@
 	}
 }
 
-@PART[fft-fusion-inertial-magnetic-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-fusion-inertial-magnetic-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -94,7 +94,7 @@
 	}
 }
 
-@PART[fft-fusion-magnetic-mirror-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-fusion-magnetic-mirror-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -102,7 +102,7 @@
 	}
 }
 
-@PART[fft-fusion-magnetic-tokamak-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-fusion-magnetic-tokamak-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -110,7 +110,7 @@
 	}
 }
 
-@PART[fft-fusion-magnetic-tokamak-aerospike-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]
+@PART[fft-fusion-magnetic-tokamak-aerospike-1]:NEEDS[FarFutureTechnologies&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{

--- a/WarpThrust/WarpThrust NFP configs.cfg
+++ b/WarpThrust/WarpThrust NFP configs.cfg
@@ -1,4 +1,4 @@
-@PART[ionArgon-0625]:NEEDS[!RealismOverhaul]
+@PART[ionArgon-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -6,7 +6,7 @@
 	}
 }
 
-@PART[ionArgon-0625-2]:NEEDS[!RealismOverhaul]
+@PART[ionArgon-0625-2]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[ionArgon-0625-3]:NEEDS[!RealismOverhaul]
+@PART[ionArgon-0625-3]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -22,7 +22,7 @@
 	}
 }
 
-@PART[ionXenon-0625]:NEEDS[!RealismOverhaul]
+@PART[ionXenon-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -30,7 +30,7 @@
 	}
 }
 
-@PART[ionXenon-0625-2]:NEEDS[!RealismOverhaul]
+@PART[ionXenon-0625-2]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -38,7 +38,7 @@
 	}
 }
 
-@PART[ionXenon-0625-3]:NEEDS[!RealismOverhaul]
+@PART[ionXenon-0625-3]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -46,7 +46,7 @@
 	}
 }
 
-@PART[mpdt-25]:NEEDS[!RealismOverhaul]
+@PART[mpdt-25]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -54,7 +54,7 @@
 	}
 }
 
-@PART[mpdt-125]:NEEDS[!RealismOverhaul]
+@PART[mpdt-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -62,7 +62,7 @@
 	}
 }
 
-@PART[mpdt-0625]:NEEDS[!RealismOverhaul]
+@PART[mpdt-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -70,7 +70,7 @@
 	}	
 }
 
-@PART[pit-25]:NEEDS[!RealismOverhaul]
+@PART[pit-25]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -78,7 +78,7 @@
 	}
 }
 
-@PART[pit-125]:NEEDS[!RealismOverhaul]
+@PART[pit-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -86,7 +86,7 @@
 	}
 }
 
-@PART[pit-0625]:NEEDS[!RealismOverhaul]
+@PART[pit-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -94,7 +94,7 @@
 	}	
 }
 
-@PART[vasimr-125]:NEEDS[!RealismOverhaul]
+@PART[vasimr-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -102,7 +102,7 @@
 	}
 }
 
-@PART[vasimr-125]:NEEDS[!RealismOverhaul]
+@PART[vasimr-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
 {
 	MODULE
 	{

--- a/WarpThrust/WarpThrust NFP configs.cfg
+++ b/WarpThrust/WarpThrust NFP configs.cfg
@@ -1,4 +1,4 @@
-@PART[ionArgon-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[ionArgon-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -6,7 +6,7 @@
 	}
 }
 
-@PART[ionArgon-0625-2]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[ionArgon-0625-2]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[ionArgon-0625-3]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[ionArgon-0625-3]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -22,7 +22,7 @@
 	}
 }
 
-@PART[ionXenon-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[ionXenon-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -30,7 +30,7 @@
 	}
 }
 
-@PART[ionXenon-0625-2]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[ionXenon-0625-2]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -38,7 +38,7 @@
 	}
 }
 
-@PART[ionXenon-0625-3]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[ionXenon-0625-3]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -46,7 +46,7 @@
 	}
 }
 
-@PART[mpdt-25]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[mpdt-25]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -54,7 +54,7 @@
 	}
 }
 
-@PART[mpdt-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[mpdt-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -62,7 +62,7 @@
 	}
 }
 
-@PART[mpdt-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[mpdt-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -70,7 +70,7 @@
 	}	
 }
 
-@PART[pit-25]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[pit-25]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -78,7 +78,7 @@
 	}
 }
 
-@PART[pit-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[pit-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -86,7 +86,7 @@
 	}
 }
 
-@PART[pit-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[pit-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -94,7 +94,7 @@
 	}	
 }
 
-@PART[vasimr-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[vasimr-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -102,7 +102,7 @@
 	}
 }
 
-@PART[vasimr-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]
+@PART[vasimr-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{


### PR DESCRIPTION
Adds NEEDS requirements for FFT and NFP
Also replaced ``FOR[RealismOverhaul]`` with ``FOR[WarpThrust]``