### PR TITLE
Fix part names in WarpThrust NFP configs.cfg

### DIFF
--- a/WarpThrust/WarpThrust NFP configs.cfg
+++ b/WarpThrust/WarpThrust NFP configs.cfg
@@ -94,7 +94,7 @@
 	}	
 }
 
-@PART[vasimr-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
+@PART[vasimr-25]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{
@@ -103,6 +103,14 @@
 }
 
 @PART[vasimr-125]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
+{
+	MODULE
+	{
+		name = WarpThrust
+	}	
+}
+
+@PART[vasimr-0625]:NEEDS[NearFuturePropulsion&!RealismOverhaul]:FOR[WarpThrust]
 {
 	MODULE
 	{


### PR DESCRIPTION
Corrects the part names for the vasimr engines in the default NFP config.